### PR TITLE
Material property system revamp

### DIFF
--- a/src/main/java/com/denizenscript/clientizen/objects/properties/PropertyRegistry.java
+++ b/src/main/java/com/denizenscript/clientizen/objects/properties/PropertyRegistry.java
@@ -1,19 +1,21 @@
 package com.denizenscript.clientizen.objects.properties;
 
-import com.denizenscript.clientizen.objects.properties.material.MaterialLevel;
-import com.denizenscript.clientizen.objects.properties.material.internal.MaterialBooleanProperty;
-import com.denizenscript.clientizen.objects.properties.material.internal.MaterialEnumProperty;
-import net.minecraft.state.property.Properties;
+import com.denizenscript.clientizen.objects.properties.material.MaterialHalf;
+import com.denizenscript.clientizen.objects.properties.material.MaterialHanging;
+import com.denizenscript.clientizen.objects.properties.material.MaterialSwitched;
+import com.denizenscript.clientizen.objects.properties.material.MaterialWaterlogged;
 
 import static com.denizenscript.clientizen.objects.properties.material.internal.MaterialMinecraftProperty.registerProperty;
+import static com.denizenscript.clientizen.objects.properties.material.internal.MaterialMinecraftProperty.registerEnumProperty;
 
 public class PropertyRegistry {
+
     public static void register() {
-        registerProperty("switched", MaterialBooleanProperty::new, MaterialBooleanProperty.class, Properties.EYE, Properties.POWERED, Properties.ENABLED);
-        registerProperty("waterlogged", MaterialBooleanProperty::new, MaterialBooleanProperty.class, Properties.WATERLOGGED);
-        registerProperty("hanging", MaterialBooleanProperty::new, MaterialBooleanProperty.class, Properties.HANGING);
-        registerProperty("bed_part", MaterialEnumProperty::new, MaterialEnumProperty.class, Properties.BED_PART);
-        registerProperty("instrument", MaterialEnumProperty::new, MaterialEnumProperty.class, Properties.INSTRUMENT);
-        registerProperty("level", MaterialLevel::new, MaterialLevel.class, MaterialLevel.handledProperties);
+        registerProperty(MaterialSwitched.class, MaterialSwitched.handledProperties);
+        registerProperty(MaterialWaterlogged.class, MaterialWaterlogged.handledProperties);
+        registerProperty(MaterialHanging.class, MaterialHanging.handledProperties);
+        registerEnumProperty(MaterialHalf.class, MaterialHalf.handledProperties);
+//        registerProperty("instrument", MaterialEnumProperty::new, MaterialEnumProperty.class, Properties.INSTRUMENT);
+//        registerProperty("level", MaterialLevel::new, MaterialLevel.class, MaterialLevel.handledProperties);
     }
 }

--- a/src/main/java/com/denizenscript/clientizen/objects/properties/PropertyRegistry.java
+++ b/src/main/java/com/denizenscript/clientizen/objects/properties/PropertyRegistry.java
@@ -2,8 +2,7 @@ package com.denizenscript.clientizen.objects.properties;
 
 import com.denizenscript.clientizen.objects.properties.material.*;
 
-import static com.denizenscript.clientizen.objects.properties.material.internal.MaterialEnumProperty.registerEnumProperty;
-import static com.denizenscript.clientizen.objects.properties.material.internal.MaterialMinecraftProperty.registerProperty;
+import static com.denizenscript.clientizen.objects.properties.material.internal.MaterialEnumProperty.registerProperty;
 
 public class PropertyRegistry {
 
@@ -11,8 +10,8 @@ public class PropertyRegistry {
         registerProperty(MaterialSwitched.class, MaterialSwitched.handledProperties);
         registerProperty(MaterialWaterlogged.class, MaterialWaterlogged.handledProperties);
         registerProperty(MaterialHanging.class, MaterialHanging.handledProperties);
-        registerEnumProperty(MaterialHalf.class, MaterialHalf.handledProperties);
-        registerEnumProperty(MaterialInstrument.class, MaterialInstrument.handledProperties);
+        registerProperty(MaterialHalf.class, MaterialHalf.handledProperties);
+        registerProperty(MaterialInstrument.class, MaterialInstrument.handledProperties);
         registerProperty(MaterialLevel.class, MaterialLevel.handledProperties);
     }
 }

--- a/src/main/java/com/denizenscript/clientizen/objects/properties/PropertyRegistry.java
+++ b/src/main/java/com/denizenscript/clientizen/objects/properties/PropertyRegistry.java
@@ -1,12 +1,9 @@
 package com.denizenscript.clientizen.objects.properties;
 
-import com.denizenscript.clientizen.objects.properties.material.MaterialHalf;
-import com.denizenscript.clientizen.objects.properties.material.MaterialHanging;
-import com.denizenscript.clientizen.objects.properties.material.MaterialSwitched;
-import com.denizenscript.clientizen.objects.properties.material.MaterialWaterlogged;
+import com.denizenscript.clientizen.objects.properties.material.*;
 
+import static com.denizenscript.clientizen.objects.properties.material.internal.MaterialEnumProperty.registerEnumProperty;
 import static com.denizenscript.clientizen.objects.properties.material.internal.MaterialMinecraftProperty.registerProperty;
-import static com.denizenscript.clientizen.objects.properties.material.internal.MaterialMinecraftProperty.registerEnumProperty;
 
 public class PropertyRegistry {
 
@@ -15,7 +12,7 @@ public class PropertyRegistry {
         registerProperty(MaterialWaterlogged.class, MaterialWaterlogged.handledProperties);
         registerProperty(MaterialHanging.class, MaterialHanging.handledProperties);
         registerEnumProperty(MaterialHalf.class, MaterialHalf.handledProperties);
-//        registerProperty("instrument", MaterialEnumProperty::new, MaterialEnumProperty.class, Properties.INSTRUMENT);
-//        registerProperty("level", MaterialLevel::new, MaterialLevel.class, MaterialLevel.handledProperties);
+        registerEnumProperty(MaterialInstrument.class, MaterialInstrument.handledProperties);
+        registerProperty(MaterialLevel.class, MaterialLevel.handledProperties);
     }
 }

--- a/src/main/java/com/denizenscript/clientizen/objects/properties/material/MaterialHalf.java
+++ b/src/main/java/com/denizenscript/clientizen/objects/properties/material/MaterialHalf.java
@@ -1,7 +1,6 @@
 package com.denizenscript.clientizen.objects.properties.material;
 
 import com.denizenscript.clientizen.objects.properties.material.internal.MaterialEnumProperty;
-import com.denizenscript.denizencore.objects.core.ElementTag;
 import net.minecraft.block.enums.BedPart;
 import net.minecraft.block.enums.ChestType;
 import net.minecraft.state.property.EnumProperty;
@@ -12,8 +11,8 @@ public class MaterialHalf extends MaterialEnumProperty {
     public static final EnumProperty<?>[] handledProperties = {Properties.BED_PART, Properties.CHEST_TYPE};
 
     @Override
-    public boolean isDefaultValue(ElementTag value) {
-        return internalProperty == Properties.BED_PART ? value.asEnum(BedPart.class) == BedPart.FOOT : value.asEnum(ChestType.class) == ChestType.SINGLE;
+    public boolean isDefaultValue(Enum<?> value) {
+        return internalProperty == Properties.BED_PART ? value == BedPart.FOOT : value == ChestType.SINGLE;
     }
 
     @Override
@@ -22,6 +21,6 @@ public class MaterialHalf extends MaterialEnumProperty {
     }
 
     public static void register() {
-        autoRegister("half", MaterialHalf.class);
+        autoRegisterEnumProperty("half", MaterialHalf.class);
     }
 }

--- a/src/main/java/com/denizenscript/clientizen/objects/properties/material/MaterialHalf.java
+++ b/src/main/java/com/denizenscript/clientizen/objects/properties/material/MaterialHalf.java
@@ -9,6 +9,6 @@ public class MaterialHalf extends MaterialEnumProperty {
     public static final EnumProperty<?>[] handledProperties = {Properties.BED_PART, Properties.CHEST_TYPE};
 
     public static void register() {
-        autoRegisterEnumProperty("half", MaterialHalf.class);
+        autoRegister("half", MaterialHalf.class);
     }
 }

--- a/src/main/java/com/denizenscript/clientizen/objects/properties/material/MaterialHalf.java
+++ b/src/main/java/com/denizenscript/clientizen/objects/properties/material/MaterialHalf.java
@@ -22,6 +22,6 @@ public class MaterialHalf extends MaterialEnumProperty {
     }
 
     public static void register() {
-        autoRegister("half", MaterialHalf.class, ElementTag.class, false);
+        autoRegister("half", MaterialHalf.class);
     }
 }

--- a/src/main/java/com/denizenscript/clientizen/objects/properties/material/MaterialHalf.java
+++ b/src/main/java/com/denizenscript/clientizen/objects/properties/material/MaterialHalf.java
@@ -1,0 +1,27 @@
+package com.denizenscript.clientizen.objects.properties.material;
+
+import com.denizenscript.clientizen.objects.properties.material.internal.MaterialEnumProperty;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import net.minecraft.block.enums.BedPart;
+import net.minecraft.block.enums.ChestType;
+import net.minecraft.state.property.EnumProperty;
+import net.minecraft.state.property.Properties;
+
+public class MaterialHalf extends MaterialEnumProperty {
+
+    public static final EnumProperty<?>[] handledProperties = {Properties.BED_PART, Properties.CHEST_TYPE};
+
+    @Override
+    public boolean isDefaultValue(ElementTag value) {
+        return internalProperty == Properties.BED_PART ? value.asEnum(BedPart.class) == BedPart.FOOT : value.asEnum(ChestType.class) == ChestType.SINGLE;
+    }
+
+    @Override
+    public String getPropertyId() {
+        return "half";
+    }
+
+    public static void register() {
+        autoRegister("half", MaterialHalf.class, ElementTag.class, false);
+    }
+}

--- a/src/main/java/com/denizenscript/clientizen/objects/properties/material/MaterialHalf.java
+++ b/src/main/java/com/denizenscript/clientizen/objects/properties/material/MaterialHalf.java
@@ -1,19 +1,12 @@
 package com.denizenscript.clientizen.objects.properties.material;
 
 import com.denizenscript.clientizen.objects.properties.material.internal.MaterialEnumProperty;
-import net.minecraft.block.enums.BedPart;
-import net.minecraft.block.enums.ChestType;
 import net.minecraft.state.property.EnumProperty;
 import net.minecraft.state.property.Properties;
 
 public class MaterialHalf extends MaterialEnumProperty {
 
     public static final EnumProperty<?>[] handledProperties = {Properties.BED_PART, Properties.CHEST_TYPE};
-
-    @Override
-    public String getPropertyId() {
-        return "half";
-    }
 
     public static void register() {
         autoRegisterEnumProperty("half", MaterialHalf.class);

--- a/src/main/java/com/denizenscript/clientizen/objects/properties/material/MaterialHalf.java
+++ b/src/main/java/com/denizenscript/clientizen/objects/properties/material/MaterialHalf.java
@@ -11,11 +11,6 @@ public class MaterialHalf extends MaterialEnumProperty {
     public static final EnumProperty<?>[] handledProperties = {Properties.BED_PART, Properties.CHEST_TYPE};
 
     @Override
-    public boolean isDefaultValue(Enum<?> value) {
-        return internalProperty == Properties.BED_PART ? value == BedPart.FOOT : value == ChestType.SINGLE;
-    }
-
-    @Override
     public String getPropertyId() {
         return "half";
     }

--- a/src/main/java/com/denizenscript/clientizen/objects/properties/material/MaterialHanging.java
+++ b/src/main/java/com/denizenscript/clientizen/objects/properties/material/MaterialHanging.java
@@ -1,7 +1,6 @@
 package com.denizenscript.clientizen.objects.properties.material;
 
 import com.denizenscript.clientizen.objects.properties.material.internal.MaterialBooleanProperty;
-import com.denizenscript.denizencore.objects.core.ElementTag;
 import net.minecraft.state.property.BooleanProperty;
 import net.minecraft.state.property.Properties;
 
@@ -10,8 +9,8 @@ public class MaterialHanging extends MaterialBooleanProperty {
     public static final BooleanProperty[] handledProperties = {Properties.HANGING};
 
     @Override
-    public boolean isDefaultValue(ElementTag value) {
-        return !value.asBoolean();
+    public boolean isDefaultValue(boolean value) {
+        return !value;
     }
 
     @Override
@@ -20,6 +19,6 @@ public class MaterialHanging extends MaterialBooleanProperty {
     }
 
     public static void register() {
-        autoRegister("hanging", MaterialHanging.class, ElementTag.class, false);
+        autoRegister("hanging", MaterialHanging.class);
     }
 }

--- a/src/main/java/com/denizenscript/clientizen/objects/properties/material/MaterialHanging.java
+++ b/src/main/java/com/denizenscript/clientizen/objects/properties/material/MaterialHanging.java
@@ -9,11 +9,6 @@ public class MaterialHanging extends MaterialBooleanProperty {
     public static final BooleanProperty[] handledProperties = {Properties.HANGING};
 
     @Override
-    public boolean isDefaultValue(boolean value) {
-        return !value;
-    }
-
-    @Override
     public String getPropertyId() {
         return "hanging";
     }

--- a/src/main/java/com/denizenscript/clientizen/objects/properties/material/MaterialHanging.java
+++ b/src/main/java/com/denizenscript/clientizen/objects/properties/material/MaterialHanging.java
@@ -8,11 +8,6 @@ public class MaterialHanging extends MaterialBooleanProperty {
 
     public static final BooleanProperty[] handledProperties = {Properties.HANGING};
 
-    @Override
-    public String getPropertyId() {
-        return "hanging";
-    }
-
     public static void register() {
         autoRegister("hanging", MaterialHanging.class);
     }

--- a/src/main/java/com/denizenscript/clientizen/objects/properties/material/MaterialHanging.java
+++ b/src/main/java/com/denizenscript/clientizen/objects/properties/material/MaterialHanging.java
@@ -1,0 +1,25 @@
+package com.denizenscript.clientizen.objects.properties.material;
+
+import com.denizenscript.clientizen.objects.properties.material.internal.MaterialBooleanProperty;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import net.minecraft.state.property.BooleanProperty;
+import net.minecraft.state.property.Properties;
+
+public class MaterialHanging extends MaterialBooleanProperty {
+
+    public static final BooleanProperty[] handledProperties = {Properties.HANGING};
+
+    @Override
+    public boolean isDefaultValue(ElementTag value) {
+        return !value.asBoolean();
+    }
+
+    @Override
+    public String getPropertyId() {
+        return "hanging";
+    }
+
+    public static void register() {
+        autoRegister("hanging", MaterialHanging.class, ElementTag.class, false);
+    }
+}

--- a/src/main/java/com/denizenscript/clientizen/objects/properties/material/MaterialInstrument.java
+++ b/src/main/java/com/denizenscript/clientizen/objects/properties/material/MaterialInstrument.java
@@ -1,0 +1,19 @@
+package com.denizenscript.clientizen.objects.properties.material;
+
+import com.denizenscript.clientizen.objects.properties.material.internal.MaterialEnumProperty;
+import net.minecraft.state.property.EnumProperty;
+import net.minecraft.state.property.Properties;
+
+public class MaterialInstrument extends MaterialEnumProperty {
+
+    public static EnumProperty<?>[] handledProperties = {Properties.INSTRUMENT};
+
+    @Override
+    public String getPropertyId() {
+        return "instrument";
+    }
+
+    public static void register() {
+        autoRegisterEnumProperty("instrument", MaterialInstrument.class);
+    }
+}

--- a/src/main/java/com/denizenscript/clientizen/objects/properties/material/MaterialInstrument.java
+++ b/src/main/java/com/denizenscript/clientizen/objects/properties/material/MaterialInstrument.java
@@ -9,6 +9,6 @@ public class MaterialInstrument extends MaterialEnumProperty {
     public static EnumProperty<?>[] handledProperties = {Properties.INSTRUMENT};
 
     public static void register() {
-        autoRegisterEnumProperty("instrument", MaterialInstrument.class);
+        autoRegister("instrument", MaterialInstrument.class);
     }
 }

--- a/src/main/java/com/denizenscript/clientizen/objects/properties/material/MaterialInstrument.java
+++ b/src/main/java/com/denizenscript/clientizen/objects/properties/material/MaterialInstrument.java
@@ -8,11 +8,6 @@ public class MaterialInstrument extends MaterialEnumProperty {
 
     public static EnumProperty<?>[] handledProperties = {Properties.INSTRUMENT};
 
-    @Override
-    public String getPropertyId() {
-        return "instrument";
-    }
-
     public static void register() {
         autoRegisterEnumProperty("instrument", MaterialInstrument.class);
     }

--- a/src/main/java/com/denizenscript/clientizen/objects/properties/material/MaterialLevel.java
+++ b/src/main/java/com/denizenscript/clientizen/objects/properties/material/MaterialLevel.java
@@ -1,28 +1,30 @@
 package com.denizenscript.clientizen.objects.properties.material;
 
 import com.denizenscript.clientizen.mixin.IntPropertyAccessor;
-import com.denizenscript.clientizen.objects.MaterialTag;
 import com.denizenscript.clientizen.objects.properties.material.internal.MaterialIntProperty;
 import com.denizenscript.denizencore.objects.core.ElementTag;
+import com.denizenscript.denizencore.objects.properties.PropertyParser;
 import net.minecraft.state.property.IntProperty;
 import net.minecraft.state.property.Properties;
 
 public class MaterialLevel extends MaterialIntProperty {
-    public MaterialLevel(String name, MaterialTag material, IntProperty internalProperty) {
-        super(name, material, internalProperty);
-    }
 
     public static final IntProperty[] handledProperties = {
             Properties.CANDLES, Properties.BITES, Properties.LEVEL_3, Properties.LEVEL_8, Properties.LEVEL_1_8, Properties.LEVEL_15
     };
 
+    @Override
+    public String getPropertyId() {
+        return "level";
+    }
+
     public static void register() {
-        registerTag(ElementTag.class, "minimum_level", (attribute, prop) -> {
+        PropertyParser.registerTag(MaterialLevel.class, ElementTag.class, "minimum_level", (attribute, prop) -> {
             return new ElementTag(((IntPropertyAccessor) prop.internalProperty).getMin());
         });
-        registerTag(ElementTag.class, "maximum_level", (attribute, prop) -> {
+        PropertyParser.registerTag(MaterialLevel.class, ElementTag.class, "maximum_level", (attribute, prop) -> {
             return new ElementTag(((IntPropertyAccessor) prop.internalProperty).getMax());
         });
-        MaterialIntProperty.register();
+//        MaterialIntProperty.register();
     }
 }

--- a/src/main/java/com/denizenscript/clientizen/objects/properties/material/MaterialLevel.java
+++ b/src/main/java/com/denizenscript/clientizen/objects/properties/material/MaterialLevel.java
@@ -25,6 +25,6 @@ public class MaterialLevel extends MaterialIntProperty {
         PropertyParser.registerTag(MaterialLevel.class, ElementTag.class, "maximum_level", (attribute, prop) -> {
             return new ElementTag(((IntPropertyAccessor) prop.internalProperty).getMax());
         });
-//        MaterialIntProperty.register();
+        autoRegister("level", MaterialLevel.class);
     }
 }

--- a/src/main/java/com/denizenscript/clientizen/objects/properties/material/MaterialLevel.java
+++ b/src/main/java/com/denizenscript/clientizen/objects/properties/material/MaterialLevel.java
@@ -13,11 +13,6 @@ public class MaterialLevel extends MaterialIntProperty {
             Properties.CANDLES, Properties.BITES, Properties.LEVEL_3, Properties.LEVEL_8, Properties.LEVEL_1_8, Properties.LEVEL_15
     };
 
-    @Override
-    public String getPropertyId() {
-        return "level";
-    }
-
     public static void register() {
         PropertyParser.registerTag(MaterialLevel.class, ElementTag.class, "minimum_level", (attribute, prop) -> {
             return new ElementTag(((IntPropertyAccessor) prop.internalProperty).getMin());

--- a/src/main/java/com/denizenscript/clientizen/objects/properties/material/MaterialSwitched.java
+++ b/src/main/java/com/denizenscript/clientizen/objects/properties/material/MaterialSwitched.java
@@ -9,14 +9,6 @@ public class MaterialSwitched extends MaterialBooleanProperty {
     public static final BooleanProperty[] handledProperties = {Properties.EYE, Properties.POWERED, Properties.ENABLED};
 
     @Override
-    public boolean isDefaultValue(boolean value) {
-        if (internalProperty == Properties.EYE || internalProperty == Properties.POWERED) {
-            return !value;
-        }
-        return value;
-    }
-
-    @Override
     public String getPropertyId() {
         return "switched";
     }

--- a/src/main/java/com/denizenscript/clientizen/objects/properties/material/MaterialSwitched.java
+++ b/src/main/java/com/denizenscript/clientizen/objects/properties/material/MaterialSwitched.java
@@ -8,11 +8,6 @@ public class MaterialSwitched extends MaterialBooleanProperty {
 
     public static final BooleanProperty[] handledProperties = {Properties.EYE, Properties.POWERED, Properties.ENABLED};
 
-    @Override
-    public String getPropertyId() {
-        return "switched";
-    }
-
     public static void register() {
         autoRegister("switched", MaterialSwitched.class);
     }

--- a/src/main/java/com/denizenscript/clientizen/objects/properties/material/MaterialSwitched.java
+++ b/src/main/java/com/denizenscript/clientizen/objects/properties/material/MaterialSwitched.java
@@ -1,7 +1,6 @@
 package com.denizenscript.clientizen.objects.properties.material;
 
 import com.denizenscript.clientizen.objects.properties.material.internal.MaterialBooleanProperty;
-import com.denizenscript.denizencore.objects.core.ElementTag;
 import net.minecraft.state.property.BooleanProperty;
 import net.minecraft.state.property.Properties;
 
@@ -10,19 +9,19 @@ public class MaterialSwitched extends MaterialBooleanProperty {
     public static final BooleanProperty[] handledProperties = {Properties.EYE, Properties.POWERED, Properties.ENABLED};
 
     @Override
+    public boolean isDefaultValue(boolean value) {
+        if (internalProperty == Properties.EYE || internalProperty == Properties.POWERED) {
+            return !value;
+        }
+        return value;
+    }
+
+    @Override
     public String getPropertyId() {
         return "switched";
     }
 
-    @Override
-    public boolean isDefaultValue(ElementTag value) {
-        if (internalProperty == Properties.EYE || internalProperty == Properties.POWERED) {
-            return !value.asBoolean();
-        }
-        return value.asBoolean();
-    }
-
     public static void register() {
-        autoRegister("switched", MaterialSwitched.class, ElementTag.class, false);
+        autoRegister("switched", MaterialSwitched.class);
     }
 }

--- a/src/main/java/com/denizenscript/clientizen/objects/properties/material/MaterialSwitched.java
+++ b/src/main/java/com/denizenscript/clientizen/objects/properties/material/MaterialSwitched.java
@@ -1,0 +1,28 @@
+package com.denizenscript.clientizen.objects.properties.material;
+
+import com.denizenscript.clientizen.objects.properties.material.internal.MaterialBooleanProperty;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import net.minecraft.state.property.BooleanProperty;
+import net.minecraft.state.property.Properties;
+
+public class MaterialSwitched extends MaterialBooleanProperty {
+
+    public static final BooleanProperty[] handledProperties = {Properties.EYE, Properties.POWERED, Properties.ENABLED};
+
+    @Override
+    public String getPropertyId() {
+        return "switched";
+    }
+
+    @Override
+    public boolean isDefaultValue(ElementTag value) {
+        if (internalProperty == Properties.EYE || internalProperty == Properties.POWERED) {
+            return !value.asBoolean();
+        }
+        return value.asBoolean();
+    }
+
+    public static void register() {
+        autoRegister("switched", MaterialSwitched.class, ElementTag.class, false);
+    }
+}

--- a/src/main/java/com/denizenscript/clientizen/objects/properties/material/MaterialWaterlogged.java
+++ b/src/main/java/com/denizenscript/clientizen/objects/properties/material/MaterialWaterlogged.java
@@ -1,0 +1,25 @@
+package com.denizenscript.clientizen.objects.properties.material;
+
+import com.denizenscript.clientizen.objects.properties.material.internal.MaterialBooleanProperty;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import net.minecraft.state.property.BooleanProperty;
+import net.minecraft.state.property.Properties;
+
+public class MaterialWaterlogged extends MaterialBooleanProperty {
+
+    public static final BooleanProperty[] handledProperties = {Properties.WATERLOGGED};
+
+    @Override
+    public String getPropertyId() {
+        return "waterlogged";
+    }
+
+    @Override
+    public boolean isDefaultValue(ElementTag value) {
+        return !value.asBoolean();
+    }
+
+    public static void register() {
+        autoRegister("waterlogged", MaterialWaterlogged.class, ElementTag.class, false);
+    }
+}

--- a/src/main/java/com/denizenscript/clientizen/objects/properties/material/MaterialWaterlogged.java
+++ b/src/main/java/com/denizenscript/clientizen/objects/properties/material/MaterialWaterlogged.java
@@ -8,11 +8,6 @@ public class MaterialWaterlogged extends MaterialBooleanProperty {
 
     public static final BooleanProperty[] handledProperties = {Properties.WATERLOGGED};
 
-    @Override
-    public String getPropertyId() {
-        return "waterlogged";
-    }
-
     public static void register() {
         autoRegister("waterlogged", MaterialWaterlogged.class);
     }

--- a/src/main/java/com/denizenscript/clientizen/objects/properties/material/MaterialWaterlogged.java
+++ b/src/main/java/com/denizenscript/clientizen/objects/properties/material/MaterialWaterlogged.java
@@ -1,7 +1,6 @@
 package com.denizenscript.clientizen.objects.properties.material;
 
 import com.denizenscript.clientizen.objects.properties.material.internal.MaterialBooleanProperty;
-import com.denizenscript.denizencore.objects.core.ElementTag;
 import net.minecraft.state.property.BooleanProperty;
 import net.minecraft.state.property.Properties;
 
@@ -10,16 +9,16 @@ public class MaterialWaterlogged extends MaterialBooleanProperty {
     public static final BooleanProperty[] handledProperties = {Properties.WATERLOGGED};
 
     @Override
+    public boolean isDefaultValue(boolean value) {
+        return !value;
+    }
+
+    @Override
     public String getPropertyId() {
         return "waterlogged";
     }
 
-    @Override
-    public boolean isDefaultValue(ElementTag value) {
-        return !value.asBoolean();
-    }
-
     public static void register() {
-        autoRegister("waterlogged", MaterialWaterlogged.class, ElementTag.class, false);
+        autoRegister("waterlogged", MaterialWaterlogged.class);
     }
 }

--- a/src/main/java/com/denizenscript/clientizen/objects/properties/material/MaterialWaterlogged.java
+++ b/src/main/java/com/denizenscript/clientizen/objects/properties/material/MaterialWaterlogged.java
@@ -9,11 +9,6 @@ public class MaterialWaterlogged extends MaterialBooleanProperty {
     public static final BooleanProperty[] handledProperties = {Properties.WATERLOGGED};
 
     @Override
-    public boolean isDefaultValue(boolean value) {
-        return !value;
-    }
-
-    @Override
     public String getPropertyId() {
         return "waterlogged";
     }

--- a/src/main/java/com/denizenscript/clientizen/objects/properties/material/internal/MaterialBooleanProperty.java
+++ b/src/main/java/com/denizenscript/clientizen/objects/properties/material/internal/MaterialBooleanProperty.java
@@ -7,13 +7,15 @@ import net.minecraft.state.property.BooleanProperty;
 public abstract class MaterialBooleanProperty extends MaterialMinecraftProperty<BooleanProperty, Boolean> {
 
     @Override
-    public ElementTag getPropertyValue() {
-        return new ElementTag(object.state.get(internalProperty));
+    @SuppressWarnings("deprecation")
+    public String getPropertyString() {
+        boolean value = object.state.get(internalProperty);
+        return isDefaultValue(value) ? null : String.valueOf(value);
     }
 
     @Override
-    public boolean isDefaultValue(ElementTag value) {
-        return isDefaultValue(value.asBoolean());
+    public ElementTag getPropertyValue() {
+        return new ElementTag(object.state.get(internalProperty));
     }
 
     public boolean isDefaultValue(boolean value) {

--- a/src/main/java/com/denizenscript/clientizen/objects/properties/material/internal/MaterialBooleanProperty.java
+++ b/src/main/java/com/denizenscript/clientizen/objects/properties/material/internal/MaterialBooleanProperty.java
@@ -12,13 +12,18 @@ public abstract class MaterialBooleanProperty extends MaterialMinecraftProperty<
     }
 
     @Override
+    public boolean isDefaultValue(ElementTag value) {
+        return isDefaultValue(value.asBoolean());
+    }
+
+    public boolean isDefaultValue(boolean value) {
+        return false;
+    }
+
+    @Override
     public void setPropertyValue(ElementTag value, Mechanism mechanism) {
         if (mechanism.requireBoolean()) {
             object.state = object.state.with(internalProperty, value.asBoolean());
         }
     }
-
-//    public static void register() {
-//        MaterialMinecraftProperty.register();
-//    }
 }

--- a/src/main/java/com/denizenscript/clientizen/objects/properties/material/internal/MaterialBooleanProperty.java
+++ b/src/main/java/com/denizenscript/clientizen/objects/properties/material/internal/MaterialBooleanProperty.java
@@ -17,7 +17,7 @@ public abstract class MaterialBooleanProperty extends MaterialMinecraftProperty<
     }
 
     public boolean isDefaultValue(boolean value) {
-        return false;
+        return value == object.state.getBlock().getDefaultState().get(internalProperty);
     }
 
     @Override

--- a/src/main/java/com/denizenscript/clientizen/objects/properties/material/internal/MaterialBooleanProperty.java
+++ b/src/main/java/com/denizenscript/clientizen/objects/properties/material/internal/MaterialBooleanProperty.java
@@ -7,19 +7,8 @@ import net.minecraft.state.property.BooleanProperty;
 public abstract class MaterialBooleanProperty extends MaterialMinecraftProperty<BooleanProperty, Boolean> {
 
     @Override
-    @SuppressWarnings("deprecation")
-    public String getPropertyString() {
-        boolean value = object.state.get(internalProperty);
-        return isDefaultValue(value) ? null : String.valueOf(value);
-    }
-
-    @Override
     public ElementTag getPropertyValue() {
         return new ElementTag(object.state.get(internalProperty));
-    }
-
-    public boolean isDefaultValue(boolean value) {
-        return value == object.state.getBlock().getDefaultState().get(internalProperty);
     }
 
     @Override

--- a/src/main/java/com/denizenscript/clientizen/objects/properties/material/internal/MaterialBooleanProperty.java
+++ b/src/main/java/com/denizenscript/clientizen/objects/properties/material/internal/MaterialBooleanProperty.java
@@ -1,20 +1,6 @@
 package com.denizenscript.clientizen.objects.properties.material.internal;
 
-import com.denizenscript.denizencore.objects.Mechanism;
-import com.denizenscript.denizencore.objects.core.ElementTag;
 import net.minecraft.state.property.BooleanProperty;
 
 public abstract class MaterialBooleanProperty extends MaterialMinecraftProperty<BooleanProperty, Boolean> {
-
-    @Override
-    public ElementTag getPropertyValue() {
-        return new ElementTag(object.state.get(internalProperty));
-    }
-
-    @Override
-    public void setPropertyValue(ElementTag value, Mechanism mechanism) {
-        if (mechanism.requireBoolean()) {
-            object.state = object.state.with(internalProperty, value.asBoolean());
-        }
-    }
 }

--- a/src/main/java/com/denizenscript/clientizen/objects/properties/material/internal/MaterialBooleanProperty.java
+++ b/src/main/java/com/denizenscript/clientizen/objects/properties/material/internal/MaterialBooleanProperty.java
@@ -1,15 +1,10 @@
 package com.denizenscript.clientizen.objects.properties.material.internal;
 
-import com.denizenscript.clientizen.objects.MaterialTag;
 import com.denizenscript.denizencore.objects.Mechanism;
 import com.denizenscript.denizencore.objects.core.ElementTag;
 import net.minecraft.state.property.BooleanProperty;
 
-public class MaterialBooleanProperty extends MaterialMinecraftProperty<BooleanProperty, Boolean> {
-
-    public MaterialBooleanProperty(String name, MaterialTag material, BooleanProperty internalProperty) {
-        super(name, material, internalProperty);
-    }
+public abstract class MaterialBooleanProperty extends MaterialMinecraftProperty<BooleanProperty, Boolean> {
 
     @Override
     public ElementTag getPropertyValue() {
@@ -23,7 +18,7 @@ public class MaterialBooleanProperty extends MaterialMinecraftProperty<BooleanPr
         }
     }
 
-    public static void register() {
-        MaterialMinecraftProperty.register();
-    }
+//    public static void register() {
+//        MaterialMinecraftProperty.register();
+//    }
 }

--- a/src/main/java/com/denizenscript/clientizen/objects/properties/material/internal/MaterialEnumProperty.java
+++ b/src/main/java/com/denizenscript/clientizen/objects/properties/material/internal/MaterialEnumProperty.java
@@ -7,7 +7,7 @@ import net.minecraft.state.property.EnumProperty;
 @SuppressWarnings({"rawtypes", "unchecked"})
 public abstract class MaterialEnumProperty extends MaterialMinecraftProperty {
 
-    public static void registerEnumProperty(Class<? extends MaterialEnumProperty> propertyClass, EnumProperty<?>... properties) {
+    public static void registerProperty(Class<? extends MaterialEnumProperty> propertyClass, EnumProperty<?>... properties) {
         PropertyParser.registerPropertyGetter(new MaterialMinecraftPropertyGetter(propertyClass, properties), MaterialTag.class, null, null, propertyClass);
     }
 }

--- a/src/main/java/com/denizenscript/clientizen/objects/properties/material/internal/MaterialEnumProperty.java
+++ b/src/main/java/com/denizenscript/clientizen/objects/properties/material/internal/MaterialEnumProperty.java
@@ -7,11 +7,6 @@ import net.minecraft.state.property.EnumProperty;
 @SuppressWarnings({"rawtypes", "unchecked"})
 public abstract class MaterialEnumProperty extends MaterialMinecraftProperty {
 
-    public static void autoRegisterEnumProperty(String name, Class<? extends MaterialEnumProperty> propertyClass) {
-        autoRegister(name, (Class<? extends MaterialMinecraftProperty<?, ?>>) propertyClass);
-    }
-
-    @SuppressWarnings({"unchecked", "rawtypes"})
     public static void registerEnumProperty(Class<? extends MaterialEnumProperty> propertyClass, EnumProperty<?>... properties) {
         PropertyParser.registerPropertyGetter(new MaterialMinecraftPropertyGetter(propertyClass, properties), MaterialTag.class, null, null, propertyClass);
     }

--- a/src/main/java/com/denizenscript/clientizen/objects/properties/material/internal/MaterialEnumProperty.java
+++ b/src/main/java/com/denizenscript/clientizen/objects/properties/material/internal/MaterialEnumProperty.java
@@ -22,7 +22,7 @@ public abstract class MaterialEnumProperty extends MaterialMinecraftProperty {
     }
 
     public boolean isDefaultValue(Enum<?> value) {
-        return false;
+        return value == ((MaterialTag) object).state.getBlock().getDefaultState().get(internalProperty);
     }
 
     @Override

--- a/src/main/java/com/denizenscript/clientizen/objects/properties/material/internal/MaterialEnumProperty.java
+++ b/src/main/java/com/denizenscript/clientizen/objects/properties/material/internal/MaterialEnumProperty.java
@@ -33,7 +33,7 @@ public abstract class MaterialEnumProperty extends MaterialMinecraftProperty {
     }
 
     public static void autoRegisterEnumProperty(String name, Class<? extends MaterialEnumProperty> propertyClass) {
-        autoRegister(name, propertyClass, ElementTag.class, false);
+        autoRegister(name, (Class<? extends MaterialMinecraftProperty<?, ?>>) propertyClass);
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})

--- a/src/main/java/com/denizenscript/clientizen/objects/properties/material/internal/MaterialEnumProperty.java
+++ b/src/main/java/com/denizenscript/clientizen/objects/properties/material/internal/MaterialEnumProperty.java
@@ -1,16 +1,11 @@
 package com.denizenscript.clientizen.objects.properties.material.internal;
 
-import com.denizenscript.clientizen.objects.MaterialTag;
 import com.denizenscript.denizencore.objects.Mechanism;
 import com.denizenscript.denizencore.objects.core.ElementTag;
 import net.minecraft.state.property.EnumProperty;
 import net.minecraft.util.StringIdentifiable;
 
-public class MaterialEnumProperty<T extends Enum<T> & StringIdentifiable> extends MaterialMinecraftProperty<EnumProperty<T>, T> {
-
-    public MaterialEnumProperty(String name, MaterialTag material, EnumProperty<T> internalProperty) {
-        super(name, material, internalProperty);
-    }
+public abstract class MaterialEnumProperty<T extends Enum<T> & StringIdentifiable> extends MaterialMinecraftProperty<EnumProperty<T>, T> {
 
     @Override
     public ElementTag getPropertyValue() {
@@ -24,7 +19,5 @@ public class MaterialEnumProperty<T extends Enum<T> & StringIdentifiable> extend
         }
     }
 
-    public static void register() {
-        MaterialMinecraftProperty.register();
-    }
+    public abstract boolean isDefaultValue(ElementTag value);
 }

--- a/src/main/java/com/denizenscript/clientizen/objects/properties/material/internal/MaterialEnumProperty.java
+++ b/src/main/java/com/denizenscript/clientizen/objects/properties/material/internal/MaterialEnumProperty.java
@@ -4,9 +4,12 @@ import com.denizenscript.clientizen.objects.MaterialTag;
 import com.denizenscript.denizencore.objects.Mechanism;
 import com.denizenscript.denizencore.objects.ObjectTag;
 import com.denizenscript.denizencore.objects.core.ElementTag;
+import com.denizenscript.denizencore.objects.properties.PropertyParser;
+import net.minecraft.state.property.EnumProperty;
 
 @SuppressWarnings({"rawtypes", "unchecked"})
 public abstract class MaterialEnumProperty extends MaterialMinecraftProperty {
+
 
     @Override
     public ElementTag getPropertyValue() {
@@ -15,10 +18,12 @@ public abstract class MaterialEnumProperty extends MaterialMinecraftProperty {
 
     @Override
     public boolean isDefaultValue(ObjectTag value) {
-        return isDefaultValue((ElementTag) value);
+        return isDefaultValue(((ElementTag) value).asEnum(internalProperty.getType()));
     }
 
-    public abstract boolean isDefaultValue(ElementTag value);
+    public boolean isDefaultValue(Enum<?> value) {
+        return false;
+    }
 
     @Override
     public void setPropertyValue(ObjectTag value, Mechanism mechanism) {
@@ -27,7 +32,12 @@ public abstract class MaterialEnumProperty extends MaterialMinecraftProperty {
         }
     }
 
-    public static void autoRegister(String name, Class<? extends MaterialEnumProperty> propertyClass) {
-        autoRegister(name, propertyClass, MaterialTag.class, false);
+    public static void autoRegisterEnumProperty(String name, Class<? extends MaterialEnumProperty> propertyClass) {
+        autoRegister(name, propertyClass, ElementTag.class, false);
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public static void registerEnumProperty(Class<? extends MaterialEnumProperty> propertyClass, EnumProperty<?>... properties) {
+        PropertyParser.registerPropertyGetter(new MaterialMinecraftPropertyGetter(propertyClass, properties), MaterialTag.class, null, null, propertyClass);
     }
 }

--- a/src/main/java/com/denizenscript/clientizen/objects/properties/material/internal/MaterialEnumProperty.java
+++ b/src/main/java/com/denizenscript/clientizen/objects/properties/material/internal/MaterialEnumProperty.java
@@ -1,26 +1,11 @@
 package com.denizenscript.clientizen.objects.properties.material.internal;
 
 import com.denizenscript.clientizen.objects.MaterialTag;
-import com.denizenscript.denizencore.objects.Mechanism;
-import com.denizenscript.denizencore.objects.ObjectTag;
-import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.objects.properties.PropertyParser;
 import net.minecraft.state.property.EnumProperty;
 
 @SuppressWarnings({"rawtypes", "unchecked"})
 public abstract class MaterialEnumProperty extends MaterialMinecraftProperty {
-
-    @Override
-    public ElementTag getPropertyValue() {
-        return new ElementTag((Enum<?>) ((MaterialTag) object).state.get(internalProperty));
-    }
-
-    @Override
-    public void setPropertyValue(ObjectTag value, Mechanism mechanism) {
-        if (mechanism.requireEnum(internalProperty.getType())) {
-            ((MaterialTag) object).state = ((MaterialTag) object).state.with(internalProperty, ((ElementTag) value).asEnum(internalProperty.getType()));
-        }
-    }
 
     public static void autoRegisterEnumProperty(String name, Class<? extends MaterialEnumProperty> propertyClass) {
         autoRegister(name, (Class<? extends MaterialMinecraftProperty<?, ?>>) propertyClass);

--- a/src/main/java/com/denizenscript/clientizen/objects/properties/material/internal/MaterialEnumProperty.java
+++ b/src/main/java/com/denizenscript/clientizen/objects/properties/material/internal/MaterialEnumProperty.java
@@ -1,23 +1,33 @@
 package com.denizenscript.clientizen.objects.properties.material.internal;
 
+import com.denizenscript.clientizen.objects.MaterialTag;
 import com.denizenscript.denizencore.objects.Mechanism;
+import com.denizenscript.denizencore.objects.ObjectTag;
 import com.denizenscript.denizencore.objects.core.ElementTag;
-import net.minecraft.state.property.EnumProperty;
-import net.minecraft.util.StringIdentifiable;
 
-public abstract class MaterialEnumProperty<T extends Enum<T> & StringIdentifiable> extends MaterialMinecraftProperty<EnumProperty<T>, T> {
+@SuppressWarnings({"rawtypes", "unchecked"})
+public abstract class MaterialEnumProperty extends MaterialMinecraftProperty {
 
     @Override
     public ElementTag getPropertyValue() {
-        return new ElementTag(object.state.get(internalProperty));
+        return new ElementTag((Enum<?>) ((MaterialTag) object).state.get(internalProperty));
     }
 
     @Override
-    public void setPropertyValue(ElementTag value, Mechanism mechanism) {
-        if (mechanism.requireEnum(internalProperty.getType())) {
-            object.state = object.state.with(internalProperty, value.asEnum(internalProperty.getType()));
-        }
+    public boolean isDefaultValue(ObjectTag value) {
+        return isDefaultValue((ElementTag) value);
     }
 
     public abstract boolean isDefaultValue(ElementTag value);
+
+    @Override
+    public void setPropertyValue(ObjectTag value, Mechanism mechanism) {
+        if (mechanism.requireEnum(internalProperty.getType())) {
+            ((MaterialTag) object).state = ((MaterialTag) object).state.with(internalProperty, ((ElementTag) value).asEnum(internalProperty.getType()));
+        }
+    }
+
+    public static void autoRegister(String name, Class<? extends MaterialEnumProperty> propertyClass) {
+        autoRegister(name, propertyClass, MaterialTag.class, false);
+    }
 }

--- a/src/main/java/com/denizenscript/clientizen/objects/properties/material/internal/MaterialEnumProperty.java
+++ b/src/main/java/com/denizenscript/clientizen/objects/properties/material/internal/MaterialEnumProperty.java
@@ -11,19 +11,8 @@ import net.minecraft.state.property.EnumProperty;
 public abstract class MaterialEnumProperty extends MaterialMinecraftProperty {
 
     @Override
-    @SuppressWarnings("deprecation")
-    public String getPropertyString() {
-        Enum<?> value = (Enum<?>) ((MaterialTag) object).state.get(internalProperty);
-        return isDefaultValue(value) ? null : value.name();
-    }
-
-    @Override
     public ElementTag getPropertyValue() {
         return new ElementTag((Enum<?>) ((MaterialTag) object).state.get(internalProperty));
-    }
-
-    public boolean isDefaultValue(Enum<?> value) {
-        return value == ((MaterialTag) object).state.getBlock().getDefaultState().get(internalProperty);
     }
 
     @Override

--- a/src/main/java/com/denizenscript/clientizen/objects/properties/material/internal/MaterialEnumProperty.java
+++ b/src/main/java/com/denizenscript/clientizen/objects/properties/material/internal/MaterialEnumProperty.java
@@ -10,15 +10,16 @@ import net.minecraft.state.property.EnumProperty;
 @SuppressWarnings({"rawtypes", "unchecked"})
 public abstract class MaterialEnumProperty extends MaterialMinecraftProperty {
 
+    @Override
+    @SuppressWarnings("deprecation")
+    public String getPropertyString() {
+        Enum<?> value = (Enum<?>) ((MaterialTag) object).state.get(internalProperty);
+        return isDefaultValue(value) ? null : value.name();
+    }
 
     @Override
     public ElementTag getPropertyValue() {
         return new ElementTag((Enum<?>) ((MaterialTag) object).state.get(internalProperty));
-    }
-
-    @Override
-    public boolean isDefaultValue(ObjectTag value) {
-        return isDefaultValue(((ElementTag) value).asEnum(internalProperty.getType()));
     }
 
     public boolean isDefaultValue(Enum<?> value) {

--- a/src/main/java/com/denizenscript/clientizen/objects/properties/material/internal/MaterialIntProperty.java
+++ b/src/main/java/com/denizenscript/clientizen/objects/properties/material/internal/MaterialIntProperty.java
@@ -6,10 +6,7 @@ import com.denizenscript.denizencore.objects.Mechanism;
 import com.denizenscript.denizencore.objects.core.ElementTag;
 import net.minecraft.state.property.IntProperty;
 
-public class MaterialIntProperty extends MaterialMinecraftProperty<IntProperty, Integer> {
-    public MaterialIntProperty(String name, MaterialTag material, IntProperty internalProperty) {
-        super(name, material, internalProperty);
-    }
+public abstract class MaterialIntProperty extends MaterialMinecraftProperty<IntProperty, Integer> {
 
     @Override
     public ElementTag getPropertyValue() {
@@ -34,7 +31,7 @@ public class MaterialIntProperty extends MaterialMinecraftProperty<IntProperty, 
         object.state = object.state.with(internalProperty, newValue);
     }
 
-    public static void register() {
-        MaterialMinecraftProperty.register();
-    }
+//    public static void register() {
+//        MaterialMinecraftProperty.register();
+//    }
 }

--- a/src/main/java/com/denizenscript/clientizen/objects/properties/material/internal/MaterialIntProperty.java
+++ b/src/main/java/com/denizenscript/clientizen/objects/properties/material/internal/MaterialIntProperty.java
@@ -19,7 +19,7 @@ public abstract class MaterialIntProperty extends MaterialMinecraftProperty<IntP
     }
 
     public boolean isDefaultValue(int value) {
-        return false;
+        return value == object.state.getBlock().getDefaultState().get(internalProperty);
     }
 
     @Override

--- a/src/main/java/com/denizenscript/clientizen/objects/properties/material/internal/MaterialIntProperty.java
+++ b/src/main/java/com/denizenscript/clientizen/objects/properties/material/internal/MaterialIntProperty.java
@@ -14,6 +14,15 @@ public abstract class MaterialIntProperty extends MaterialMinecraftProperty<IntP
     }
 
     @Override
+    public boolean isDefaultValue(ElementTag value) {
+        return isDefaultValue(value.asInt());
+    }
+
+    public boolean isDefaultValue(int value) {
+        return false;
+    }
+
+    @Override
     public void setPropertyValue(ElementTag value, Mechanism mechanism) {
         if (!mechanism.requireInteger()) {
             return;
@@ -30,8 +39,4 @@ public abstract class MaterialIntProperty extends MaterialMinecraftProperty<IntP
         }
         object.state = object.state.with(internalProperty, newValue);
     }
-
-//    public static void register() {
-//        MaterialMinecraftProperty.register();
-//    }
 }

--- a/src/main/java/com/denizenscript/clientizen/objects/properties/material/internal/MaterialIntProperty.java
+++ b/src/main/java/com/denizenscript/clientizen/objects/properties/material/internal/MaterialIntProperty.java
@@ -8,11 +8,6 @@ import net.minecraft.state.property.IntProperty;
 public abstract class MaterialIntProperty extends MaterialMinecraftProperty<IntProperty, Integer> {
 
     @Override
-    public ElementTag getPropertyValue() {
-        return new ElementTag(object.state.get(internalProperty));
-    }
-
-    @Override
     public void setPropertyValue(ElementTag value, Mechanism mechanism) {
         if (!mechanism.requireInteger()) {
             return;

--- a/src/main/java/com/denizenscript/clientizen/objects/properties/material/internal/MaterialIntProperty.java
+++ b/src/main/java/com/denizenscript/clientizen/objects/properties/material/internal/MaterialIntProperty.java
@@ -8,19 +8,8 @@ import net.minecraft.state.property.IntProperty;
 public abstract class MaterialIntProperty extends MaterialMinecraftProperty<IntProperty, Integer> {
 
     @Override
-    @SuppressWarnings("deprecation")
-    public String getPropertyString() {
-        int value = object.state.get(internalProperty);
-        return isDefaultValue(value) ? null : String.valueOf(value);
-    }
-
-    @Override
     public ElementTag getPropertyValue() {
         return new ElementTag(object.state.get(internalProperty));
-    }
-
-    public boolean isDefaultValue(int value) {
-        return value == object.state.getBlock().getDefaultState().get(internalProperty);
     }
 
     @Override

--- a/src/main/java/com/denizenscript/clientizen/objects/properties/material/internal/MaterialIntProperty.java
+++ b/src/main/java/com/denizenscript/clientizen/objects/properties/material/internal/MaterialIntProperty.java
@@ -1,7 +1,6 @@
 package com.denizenscript.clientizen.objects.properties.material.internal;
 
 import com.denizenscript.clientizen.mixin.IntPropertyAccessor;
-import com.denizenscript.clientizen.objects.MaterialTag;
 import com.denizenscript.denizencore.objects.Mechanism;
 import com.denizenscript.denizencore.objects.core.ElementTag;
 import net.minecraft.state.property.IntProperty;
@@ -9,13 +8,15 @@ import net.minecraft.state.property.IntProperty;
 public abstract class MaterialIntProperty extends MaterialMinecraftProperty<IntProperty, Integer> {
 
     @Override
-    public ElementTag getPropertyValue() {
-        return new ElementTag(object.state.get(internalProperty));
+    @SuppressWarnings("deprecation")
+    public String getPropertyString() {
+        int value = object.state.get(internalProperty);
+        return isDefaultValue(value) ? null : String.valueOf(value);
     }
 
     @Override
-    public boolean isDefaultValue(ElementTag value) {
-        return isDefaultValue(value.asInt());
+    public ElementTag getPropertyValue() {
+        return new ElementTag(object.state.get(internalProperty));
     }
 
     public boolean isDefaultValue(int value) {

--- a/src/main/java/com/denizenscript/clientizen/objects/properties/material/internal/MaterialMinecraftProperty.java
+++ b/src/main/java/com/denizenscript/clientizen/objects/properties/material/internal/MaterialMinecraftProperty.java
@@ -28,7 +28,7 @@ public abstract class MaterialMinecraftProperty<T extends Property<V>, V extends
     @SuppressWarnings("deprecation")
     public String getPropertyString() {
         V value = object.state.get(internalProperty);
-        return isDefaultValue(value) ? null : String.valueOf(value);
+        return isDefaultValue(value) ? null : value.toString();
     }
 
     public boolean isDefaultValue(V value) {

--- a/src/main/java/com/denizenscript/clientizen/objects/properties/material/internal/MaterialMinecraftProperty.java
+++ b/src/main/java/com/denizenscript/clientizen/objects/properties/material/internal/MaterialMinecraftProperty.java
@@ -24,6 +24,17 @@ public abstract class MaterialMinecraftProperty<T extends Property<V>, V extends
         return propertyID;
     }
 
+    @Override
+    @SuppressWarnings("deprecation")
+    public String getPropertyString() {
+        V value = object.state.get(internalProperty);
+        return isDefaultValue(value) ? null : String.valueOf(value);
+    }
+
+    public boolean isDefaultValue(V value) {
+        return value == object.state.getBlock().getDefaultState().get(internalProperty);
+    }
+
     @SafeVarargs
     public static <T extends Property<V>, V extends Comparable<V>> void registerProperty(Class<? extends MaterialMinecraftProperty<T, V>> propertyClass, T... properties) {
         PropertyParser.registerPropertyGetter(new MaterialMinecraftPropertyGetter<>(propertyClass, properties), MaterialTag.class, null, null, propertyClass);

--- a/src/main/java/com/denizenscript/clientizen/objects/properties/material/internal/MaterialMinecraftProperty.java
+++ b/src/main/java/com/denizenscript/clientizen/objects/properties/material/internal/MaterialMinecraftProperty.java
@@ -1,82 +1,58 @@
 package com.denizenscript.clientizen.objects.properties.material.internal;
 
 import com.denizenscript.clientizen.objects.MaterialTag;
-import com.denizenscript.denizencore.objects.ObjectTag;
 import com.denizenscript.denizencore.objects.core.ElementTag;
 import com.denizenscript.denizencore.objects.properties.ObjectProperty;
 import com.denizenscript.denizencore.objects.properties.PropertyParser;
+import com.denizenscript.denizencore.utilities.debugging.Debug;
 import com.denizenscript.denizencore.utilities.debugging.DebugInternals;
+import net.minecraft.state.property.EnumProperty;
 import net.minecraft.state.property.Property;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
 
 public abstract class MaterialMinecraftProperty<T extends Property<V>, V extends Comparable<V>> extends ObjectProperty<MaterialTag, ElementTag> {
 
-    public static String currentlyRegistering;
+    public T internalProperty;
 
-    public final T internalProperty;
-    public final String name;
-
-    public MaterialMinecraftProperty(String name, MaterialTag material, T internalProperty) {
-        this.name = name;
-        this.object = material;
-        this.internalProperty = internalProperty;
-    }
-
-    @Override
-    public String getPropertyId() {
-        return name;
-    }
-
-    public static void register() {
-        registerTag(ElementTag.class, currentlyRegistering, (attribute, prop) -> prop.getPropertyValue());
-        registerMechanism(ElementTag.class, currentlyRegistering, (prop, mechanism, input) -> prop.setPropertyValue(input, mechanism));
-    }
-
-    @SuppressWarnings("unchecked")
-    public static <T extends MaterialMinecraftProperty<?, ?>, R extends ObjectTag> void registerTag(Class<R> returnType, String name, PropertyParser.PropertyTagWithReturn<T, R> runnable) {
-        final MaterialMinecraftPropertyGetter<?, ?> getter = (MaterialMinecraftPropertyGetter<?, ?>) PropertyParser.currentlyRegisteringProperty;
-        final String propertyName = currentlyRegistering;
-        MaterialTag.tagProcessor.registerTag(returnType, name, (attribute, object) -> {
-            ObjectProperty<MaterialTag, ElementTag> prop = getter.get(object);
-            if (prop == null) {
-                attribute.echoError("Property 'MaterialTag." + propertyName + "' does not describe the input object.");
-                return null;
-            }
-            return runnable.run(attribute, (T) prop);
-        });
-    }
-
-    @SuppressWarnings("unchecked")
-    public static <T extends MaterialMinecraftProperty<?, ?>, P extends ObjectTag> void registerMechanism(Class<P> paramType, String name, PropertyParser.PropertyMechanismWithParam<T, P> runner) {
-        final MaterialMinecraftPropertyGetter<?, ?> getter = (MaterialMinecraftPropertyGetter<?, ?>) PropertyParser.currentlyRegisteringProperty;
-        final String propertyName = currentlyRegistering;
-        MaterialTag.tagProcessor.registerMechanism(name, true, (object, mechanism) -> {
-            ObjectProperty<MaterialTag, ElementTag> prop = getter.get(object);
-            if (prop == null) {
-                mechanism.echoError("Property 'MaterialTag." + propertyName + "' does not describe the input object.");
-                return;
-            }
-            if (mechanism.value == null) {
-                mechanism.echoError("Error: mechanism '" + name + "' must have input of type '" + DebugInternals.getClassNameOpti(paramType) + "', but none was given.");
-                return;
-            }
-            P input = mechanism.value.asType(paramType, mechanism.context);
-            if (input == null) {
-                mechanism.echoError("Error: mechanism '" + name + "' must have input of type '" + DebugInternals.getClassNameOpti(paramType) + "', but value '" + mechanism.value + "' cannot be converted to the required type.");
-                return;
-            }
-            runner.run((T) prop, mechanism, input);
-        });
-    }
+    protected MaterialMinecraftProperty() {}
 
     @SafeVarargs
-    public static <T extends Property<V>, V extends Comparable<V>> void registerProperty(String name, MaterialMinecraftPropertySupplier<T> supplier, Class<? extends com.denizenscript.denizencore.objects.properties.Property> propertyClass, T... properties) {
-        currentlyRegistering = name;
-        PropertyParser.registerPropertyGetter(new MaterialMinecraftPropertyGetter<>(name, supplier, properties), MaterialTag.class, null, null, propertyClass);
-        currentlyRegistering = null;
+    public static <T extends Property<V>, V extends Comparable<V>> void registerProperty(Class<? extends MaterialMinecraftProperty<T, V>> propertyClass, T... properties) {
+        PropertyParser.registerPropertyGetter(new MaterialMinecraftPropertyGetter<>(propertyClass, properties), MaterialTag.class, null, null, propertyClass);
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    public static void registerEnumProperty(Class<? extends MaterialEnumProperty> propertyClass, EnumProperty<?>... properties) {
+        PropertyParser.registerPropertyGetter(new MaterialMinecraftPropertyGetter(propertyClass, properties), MaterialTag.class, null, null, propertyClass);
     }
 
     public record MaterialMinecraftPropertyGetter<T extends Property<V>, V extends Comparable<V>>
-            (String name, MaterialMinecraftPropertySupplier<T> supplier, T[] internalProperties) implements PropertyParser.PropertyGetter<MaterialTag> {
+            (MethodHandle constructor, T[] internalProperties) implements PropertyParser.PropertyGetter<MaterialTag> {
+
+        private static final MethodHandles.Lookup LOOKUP = MethodHandles.lookup();
+        private static final MethodType PROPERTY_CONSTRUCTOR = MethodType.methodType(void.class);
+
+        private static MethodHandle getConstructor(Class<? extends MaterialMinecraftProperty<?, ?>> propertyClass) {
+            try {
+                return LOOKUP.findConstructor(propertyClass, PROPERTY_CONSTRUCTOR);
+            }
+            catch (NoSuchMethodException noSuchMethodException) {
+                Debug.echoError("Invalid material minecraft property class '" + DebugInternals.getClassNameOpti(propertyClass) + "' is missing a no-args constructor!");
+                throw new IllegalArgumentException(noSuchMethodException);
+            }
+            catch (IllegalAccessException illegalAccessException) {
+                Debug.echoError("Unable to get constructor from material minecraft property class '" + DebugInternals.getClassNameOpti(propertyClass) + "'!");
+                throw new IllegalArgumentException(illegalAccessException);
+            }
+        }
+
+        public MaterialMinecraftPropertyGetter(Class<? extends MaterialMinecraftProperty<T, V>> propertyClass, T[] internalProperties) {
+            this(getConstructor(propertyClass), internalProperties);
+        }
+
 
         @Override
         public ObjectProperty<MaterialTag, ElementTag> get(MaterialTag material) {
@@ -85,15 +61,21 @@ public abstract class MaterialMinecraftProperty<T extends Property<V>, V extends
             }
             for (T internalProperty : internalProperties) {
                 if (material.state.contains(internalProperty)) {
-                    return supplier.create(name, material, internalProperty);
+                    try {
+                        //noinspection unchecked
+                        MaterialMinecraftProperty<T, ?> property = (MaterialMinecraftProperty<T, ?>) constructor.invoke();
+                        property.object = material;
+                        property.internalProperty = internalProperty;
+                        return property;
+                    }
+                    catch (Throwable e) {
+                        Debug.echoError("Exception while constructing property '" + DebugInternals.getClassNameOpti(constructor.type().returnType()) + "':");
+                        Debug.echoError(e);
+                        return null;
+                    }
                 }
             }
             return null;
         }
-    }
-
-    @FunctionalInterface
-    public interface MaterialMinecraftPropertySupplier<T extends Property<?>> {
-        MaterialMinecraftProperty<?, ?> create(String name, MaterialTag material, T internalProperty);
     }
 }

--- a/src/main/java/com/denizenscript/clientizen/objects/properties/material/internal/MaterialMinecraftProperty.java
+++ b/src/main/java/com/denizenscript/clientizen/objects/properties/material/internal/MaterialMinecraftProperty.java
@@ -24,28 +24,23 @@ public abstract class MaterialMinecraftProperty<T extends Property<V>, V extends
         PropertyParser.registerPropertyGetter(new MaterialMinecraftPropertyGetter<>(propertyClass, properties), MaterialTag.class, null, null, propertyClass);
     }
 
-    @SuppressWarnings({"unchecked", "rawtypes"})
-    public static void registerEnumProperty(Class<? extends MaterialEnumProperty> propertyClass, EnumProperty<?>... properties) {
-        PropertyParser.registerPropertyGetter(new MaterialMinecraftPropertyGetter(propertyClass, properties), MaterialTag.class, null, null, propertyClass);
+    public static void autoRegister(String name, Class<? extends MaterialMinecraftProperty<?, ?>> propertyClass) {
+        autoRegister(name, propertyClass, ElementTag.class, false);
     }
 
     public record MaterialMinecraftPropertyGetter<T extends Property<V>, V extends Comparable<V>>
             (MethodHandle constructor, T[] internalProperties) implements PropertyParser.PropertyGetter<MaterialTag> {
 
         private static final MethodHandles.Lookup LOOKUP = MethodHandles.lookup();
-        private static final MethodType PROPERTY_CONSTRUCTOR = MethodType.methodType(void.class);
+        private static final MethodType NO_ARGS_CONSTRUCTOR = MethodType.methodType(void.class);
 
         private static MethodHandle getConstructor(Class<? extends MaterialMinecraftProperty<?, ?>> propertyClass) {
             try {
-                return LOOKUP.findConstructor(propertyClass, PROPERTY_CONSTRUCTOR);
+                return LOOKUP.findConstructor(propertyClass, NO_ARGS_CONSTRUCTOR);
             }
-            catch (NoSuchMethodException noSuchMethodException) {
-                Debug.echoError("Invalid material minecraft property class '" + DebugInternals.getClassNameOpti(propertyClass) + "' is missing a no-args constructor!");
-                throw new IllegalArgumentException(noSuchMethodException);
-            }
-            catch (IllegalAccessException illegalAccessException) {
+            catch (Exception e) {
                 Debug.echoError("Unable to get constructor from material minecraft property class '" + DebugInternals.getClassNameOpti(propertyClass) + "'!");
-                throw new IllegalArgumentException(illegalAccessException);
+                throw new IllegalArgumentException(e);
             }
         }
 

--- a/src/main/java/com/denizenscript/clientizen/objects/properties/material/internal/MaterialMinecraftProperty.java
+++ b/src/main/java/com/denizenscript/clientizen/objects/properties/material/internal/MaterialMinecraftProperty.java
@@ -55,7 +55,8 @@ public abstract class MaterialMinecraftProperty<T extends Property<V>, V extends
         PropertyParser.registerPropertyGetter(new MaterialMinecraftPropertyGetter<>(propertyClass, properties), MaterialTag.class, null, null, propertyClass);
     }
 
-    public static void autoRegister(String name, Class<? extends MaterialMinecraftProperty<?, ?>> propertyClass) {
+    @SuppressWarnings({"rawtypes", "unchecked"}) // Erase types to allow enum properties
+    public static void autoRegister(String name, Class<? extends MaterialMinecraftProperty> propertyClass) {
         ((MaterialMinecraftPropertyGetter<?, ?>) PropertyParser.currentlyRegisteringProperty).propertyID = name;
         autoRegister(name, propertyClass, ElementTag.class, false);
     }


### PR DESCRIPTION
## Changes

- All properties now use their own class (to easily add extra tags/mechs when needed, have a place to put the meta, and move closer to Core's system)
- `MaterialMinecraftProperty` is now abstract, implements `ObjectProperty`, and has handling for getting/setting the property value, checking if it's the default, getting the property string, and the property registration/getter logic.
- `MaterialMinecraftPropertyGetter` now gets the property class's no-args constructor using the `MethodHandle` API (can think of it like reflection in this context), and constructs + sets fields on it, to avoid having to implement the same constructor for every class.
- `MaterialBooleanProperty`, `MaterialIntProperty`, `MaterialEnumProperty` are now abstract. must of the handling is in `MaterialMinecraftProperty`, but they're still there for property classes to implement, in addition to `MaterialEnumProperty` having the enum property registration method, and `MaterialIntProperty` having it's own input checking to better handle the min/max range.

## Notes

- This PR doesn't properly finish up the properties, currently they're mostly there for testing.
- The enum property handling is uh, not optimal, but due to generics there isn't really a way to handle this without type erasure (as far as I can see).