### PR TITLE
Add `ItemTag`

### DIFF
--- a/src/main/java/com/denizenscript/clientizen/objects/ClientizenObjectRegistry.java
+++ b/src/main/java/com/denizenscript/clientizen/objects/ClientizenObjectRegistry.java
@@ -8,10 +8,12 @@ public class ClientizenObjectRegistry {
     public static ObjectType<EntityTag> TYPE_ENTITY;
     public static ObjectType<LocationTag> TYPE_LOCATION;
     public static ObjectType<MaterialTag> TYPE_MATERIAL;
+    public static ObjectType<ItemTag> TYPE_ITEM;
 
     public static void registerObjects() {
         TYPE_ENTITY = ObjectFetcher.registerWithObjectFetcher(EntityTag.class, EntityTag.tagProcessor).setAsNOtherCode().generateBaseTag();
         TYPE_LOCATION = ObjectFetcher.registerWithObjectFetcher(LocationTag.class, LocationTag.tagProcessor).setAsNOtherCode().setCanConvertStatic().generateBaseTag();
         TYPE_MATERIAL = ObjectFetcher.registerWithObjectFetcher(MaterialTag.class, MaterialTag.tagProcessor).generateBaseTag();
+        TYPE_ITEM = ObjectFetcher.registerWithObjectFetcher(ItemTag.class, ItemTag.tagProcessor).setAsNOtherCode().generateBaseTag();
     }
 }

--- a/src/main/java/com/denizenscript/clientizen/objects/ItemTag.java
+++ b/src/main/java/com/denizenscript/clientizen/objects/ItemTag.java
@@ -15,6 +15,7 @@ import net.minecraft.util.Identifier;
 public class ItemTag implements ObjectTag, Adjustable {
 
     final ItemStack itemStack;
+    public String script; // Compact with server-side item scripts
 
     public ItemTag(ItemStack itemStack) {
         this.itemStack = itemStack;

--- a/src/main/java/com/denizenscript/clientizen/objects/ItemTag.java
+++ b/src/main/java/com/denizenscript/clientizen/objects/ItemTag.java
@@ -76,23 +76,23 @@ public class ItemTag implements ObjectTag, Adjustable {
         return itemStack;
     }
 
-    public String getKey() {
+    public String getName() {
         return Utilities.idToString(Registries.ITEM.getId(itemStack.getItem()));
     }
 
     @Override
     public String identify() {
-        return "i@" + getKey() + PropertyParser.getPropertiesString(this);
+        return "i@" + getName() + PropertyParser.getPropertiesString(this);
     }
 
     @Override
     public String identifySimple() {
-        return "i@" + getKey();
+        return "i@" + getName();
     }
 
     @Override
     public String debuggable() {
-        return "<LG>i@<Y>" + getKey() + PropertyParser.getPropertiesDebuggable(this);
+        return "<LG>i@<Y>" + getName() + PropertyParser.getPropertiesDebuggable(this);
     }
 
     @Override

--- a/src/main/java/com/denizenscript/clientizen/objects/ItemTag.java
+++ b/src/main/java/com/denizenscript/clientizen/objects/ItemTag.java
@@ -30,10 +30,8 @@ public class ItemTag implements ObjectTag, Adjustable {
     // @description
     // An ItemTag represents a holdable item generically.
     //
-    // ItemTags are temporary objects, to actually modify an item in an inventory you must add the item into that inventory.
-    //
-    // ItemTags do NOT remember where they came from. If you read an item from an inventory, changing it
-    // does not change the original item in the original inventory. You must set it back in.
+    // ItemTags do NOT remember where they came from. If you read an item from somewhere, changing it
+    // does not change the original item. You must set it back in.
     //
     // Find a list of valid materials at <@link url https://hub.spigotmc.org/javadocs/spigot/org/bukkit/Material.html>
     // Note that some materials on that list are exclusively for use with blocks, and cannot be held as items.

--- a/src/main/java/com/denizenscript/clientizen/objects/ItemTag.java
+++ b/src/main/java/com/denizenscript/clientizen/objects/ItemTag.java
@@ -1,0 +1,119 @@
+package com.denizenscript.clientizen.objects;
+
+import com.denizenscript.clientizen.util.Utilities;
+import com.denizenscript.denizencore.objects.*;
+import com.denizenscript.denizencore.objects.properties.PropertyParser;
+import com.denizenscript.denizencore.tags.Attribute;
+import com.denizenscript.denizencore.tags.ObjectTagProcessor;
+import com.denizenscript.denizencore.tags.TagContext;
+import com.denizenscript.denizencore.utilities.debugging.Debug;
+import net.minecraft.item.ItemConvertible;
+import net.minecraft.item.ItemStack;
+import net.minecraft.registry.Registries;
+import net.minecraft.util.Identifier;
+
+public class ItemTag implements ObjectTag, Adjustable {
+
+    final ItemStack itemStack;
+
+    public ItemTag(ItemStack itemStack) {
+        this.itemStack = itemStack;
+    }
+
+    public ItemTag(ItemConvertible convertible) {
+        this(convertible.asItem().getDefaultStack());
+    }
+
+    @Fetchable("i")
+    public static ItemTag valueOf(String string, TagContext context) {
+        if (string.startsWith("i@")) {
+            string = string.substring("i@".length());
+        }
+        if (ObjectFetcher.isObjectWithProperties(string)) {
+            return ObjectFetcher.getObjectFromWithProperties(ClientizenObjectRegistry.TYPE_ITEM, string, context);
+        }
+        MaterialTag material = MaterialTag.valueOf(string, context);
+        if (material == null) {
+            if (context == null || context.showErrors()) {
+                Debug.echoError("valueOf ItemTag returning null: invalid item type '" + string + "' specified.");
+            }
+            return null;
+        }
+        return new ItemTag(material.state != null ? material.state.getBlock() : material.item);
+    }
+
+    public static boolean matches(String string) {
+        if (string.startsWith("i@")) {
+            return true;
+        }
+        Identifier identifier = Identifier.tryParse(string);
+        return identifier != null && (Registries.ITEM.containsId(identifier) || Registries.BLOCK.containsId(identifier));
+    }
+
+    public static void register() {
+        PropertyParser.registerPropertyTagHandlers(ItemTag.class, tagProcessor);
+    }
+
+    public static final ObjectTagProcessor<ItemTag> tagProcessor = new ObjectTagProcessor<>();
+
+    @Override
+    public ObjectTag getObjectAttribute(Attribute attribute) {
+        return tagProcessor.getObjectAttribute(this, attribute);
+    }
+
+    @Override
+    public void adjust(Mechanism mechanism) {
+        tagProcessor.processMechanism(this, mechanism);
+    }
+
+    @Override
+    public void applyProperty(Mechanism mechanism) {
+        adjust(mechanism);
+    }
+
+    public ItemStack getStack() {
+        return itemStack;
+    }
+
+    public String getKey() {
+        return Utilities.idToString(Registries.ITEM.getId(itemStack.getItem()));
+    }
+
+    @Override
+    public String identify() {
+        return "i@" + getKey() + PropertyParser.getPropertiesString(this);
+    }
+
+    @Override
+    public String identifySimple() {
+        return "i@" + getKey();
+    }
+
+    @Override
+    public String debuggable() {
+        return "<LG>i@<Y>" + getKey() + PropertyParser.getPropertiesDebuggable(this);
+    }
+
+    @Override
+    public String toString() {
+        return identify();
+    }
+
+    @Override
+    public boolean isUnique() {
+        return false;
+    }
+
+    String prefix = "Item";
+
+    @Override
+    public String getPrefix() {
+        return prefix;
+    }
+
+    @Override
+    public ObjectTag setPrefix(String prefix) {
+        this.prefix = prefix;
+        return this;
+    }
+}

--- a/src/main/java/com/denizenscript/clientizen/objects/ItemTag.java
+++ b/src/main/java/com/denizenscript/clientizen/objects/ItemTag.java
@@ -39,10 +39,12 @@ public class ItemTag implements ObjectTag, Adjustable {
     // -->
 
     final ItemStack itemStack;
+    final Identifier identifier;
     public String script; // Compact with server-side item scripts
 
     public ItemTag(ItemStack itemStack) {
         this.itemStack = itemStack;
+        this.identifier = Registries.ITEM.getId(itemStack.getItem());
     }
 
     public ItemTag(ItemConvertible convertible) {
@@ -105,7 +107,7 @@ public class ItemTag implements ObjectTag, Adjustable {
     }
 
     public String getName() {
-        return Utilities.idToString(Registries.ITEM.getId(itemStack.getItem()));
+        return Utilities.idToString(identifier);
     }
 
     @Override

--- a/src/main/java/com/denizenscript/clientizen/objects/ItemTag.java
+++ b/src/main/java/com/denizenscript/clientizen/objects/ItemTag.java
@@ -14,6 +14,32 @@ import net.minecraft.util.Identifier;
 
 public class ItemTag implements ObjectTag, Adjustable {
 
+    // <--[ObjectType]
+    // @name ItemTag
+    // @prefix i
+    // @base ElementTag
+    // @implements PropertyHolderObject
+    // @ExampleTagBase client.self_entity.item_in_hand
+    // @ExampleValues <client.self_entity.item_in_hand>,stick,iron_sword
+    // @ExampleForReturns
+    // - narrate "The item is %VALUE%"
+    // @format
+    // The identity format for items is the basic material type name. Other data is specified in properties.
+    // For example, 'i@stick'.
+    //
+    // @description
+    // An ItemTag represents a holdable item generically.
+    //
+    // ItemTags are temporary objects, to actually modify an item in an inventory you must add the item into that inventory.
+    //
+    // ItemTags do NOT remember where they came from. If you read an item from an inventory, changing it
+    // does not change the original item in the original inventory. You must set it back in.
+    //
+    // Find a list of valid materials at <@link url https://hub.spigotmc.org/javadocs/spigot/org/bukkit/Material.html>
+    // Note that some materials on that list are exclusively for use with blocks, and cannot be held as items.
+    //
+    // -->
+
     final ItemStack itemStack;
     public String script; // Compact with server-side item scripts
 

--- a/src/main/java/com/denizenscript/clientizen/objects/ItemTag.java
+++ b/src/main/java/com/denizenscript/clientizen/objects/ItemTag.java
@@ -49,6 +49,10 @@ public class ItemTag implements ObjectTag, Adjustable {
         this(convertible.asItem().getDefaultStack());
     }
 
+    public ItemTag(MaterialTag material) {
+        this(material.item != null ? material.item : material.state.getBlock());
+    }
+
     @Fetchable("i")
     public static ItemTag valueOf(String string, TagContext context) {
         if (string.startsWith("i@")) {
@@ -64,7 +68,7 @@ public class ItemTag implements ObjectTag, Adjustable {
             }
             return null;
         }
-        return new ItemTag(material.state != null ? material.state.getBlock() : material.item);
+        return new ItemTag(material);
     }
 
     public static boolean matches(String string) {

--- a/src/main/java/com/denizenscript/clientizen/objects/properties/PropertyRegistry.java
+++ b/src/main/java/com/denizenscript/clientizen/objects/properties/PropertyRegistry.java
@@ -1,6 +1,9 @@
 package com.denizenscript.clientizen.objects.properties;
 
+import com.denizenscript.clientizen.objects.ItemTag;
+import com.denizenscript.clientizen.objects.properties.item.ItemDurability;
 import com.denizenscript.clientizen.objects.properties.material.*;
+import com.denizenscript.denizencore.objects.properties.PropertyParser;
 
 import static com.denizenscript.clientizen.objects.properties.material.internal.MaterialEnumProperty.registerProperty;
 
@@ -13,5 +16,6 @@ public class PropertyRegistry {
         registerProperty(MaterialHalf.class, MaterialHalf.handledProperties);
         registerProperty(MaterialInstrument.class, MaterialInstrument.handledProperties);
         registerProperty(MaterialLevel.class, MaterialLevel.handledProperties);
+        PropertyParser.registerProperty(ItemDurability.class, ItemTag.class);
     }
 }

--- a/src/main/java/com/denizenscript/clientizen/objects/properties/PropertyRegistry.java
+++ b/src/main/java/com/denizenscript/clientizen/objects/properties/PropertyRegistry.java
@@ -2,6 +2,7 @@ package com.denizenscript.clientizen.objects.properties;
 
 import com.denizenscript.clientizen.objects.ItemTag;
 import com.denizenscript.clientizen.objects.properties.item.ItemDurability;
+import com.denizenscript.clientizen.objects.properties.item.ItemServerScript;
 import com.denizenscript.clientizen.objects.properties.material.*;
 import com.denizenscript.denizencore.objects.properties.PropertyParser;
 
@@ -17,5 +18,6 @@ public class PropertyRegistry {
         registerProperty(MaterialInstrument.class, MaterialInstrument.handledProperties);
         registerProperty(MaterialLevel.class, MaterialLevel.handledProperties);
         PropertyParser.registerProperty(ItemDurability.class, ItemTag.class);
+        PropertyParser.registerProperty(ItemServerScript.class, ItemTag.class);
     }
 }

--- a/src/main/java/com/denizenscript/clientizen/objects/properties/PropertyRegistry.java
+++ b/src/main/java/com/denizenscript/clientizen/objects/properties/PropertyRegistry.java
@@ -1,10 +1,10 @@
 package com.denizenscript.clientizen.objects.properties;
 
+import com.denizenscript.clientizen.objects.EntityTag;
 import com.denizenscript.clientizen.objects.ItemTag;
+import com.denizenscript.clientizen.objects.properties.entity.EntitySheared;
 import com.denizenscript.clientizen.objects.properties.item.ItemDurability;
 import com.denizenscript.clientizen.objects.properties.item.ItemServerScript;
-import com.denizenscript.clientizen.objects.EntityTag;
-import com.denizenscript.clientizen.objects.properties.entity.EntitySheared;
 import com.denizenscript.clientizen.objects.properties.material.*;
 import com.denizenscript.denizencore.objects.properties.PropertyParser;
 

--- a/src/main/java/com/denizenscript/clientizen/objects/properties/item/ItemDurability.java
+++ b/src/main/java/com/denizenscript/clientizen/objects/properties/item/ItemDurability.java
@@ -1,0 +1,46 @@
+package com.denizenscript.clientizen.objects.properties.item;
+
+import com.denizenscript.clientizen.objects.ItemTag;
+import com.denizenscript.denizencore.objects.Mechanism;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+
+public class ItemDurability extends ItemProperty<ElementTag> {
+
+    // <--[property]
+    // @object ItemTag
+    // @name durability
+    // @input ElementTag(Number)
+    // @description
+    // The amount of durability an item lost.
+    // -->
+
+    public static boolean describes(ItemTag item) {
+        return item.getStack().isDamageable();
+    }
+
+    @Override
+    public ElementTag getPropertyValue() {
+        return new ElementTag(getStack().getDamage());
+    }
+
+    @Override
+    public boolean isDefaultValue(ElementTag value) {
+        return value.asInt() <= 0;
+    }
+
+    @Override
+    public String getPropertyId() {
+        return "durability";
+    }
+
+    @Override
+    public void setPropertyValue(ElementTag value, Mechanism mechanism) {
+        if (mechanism.requireInteger()) {
+            getStack().setDamage(value.asInt());
+        }
+    }
+
+    public static void register() {
+        autoRegister("durability", ItemDurability.class, ElementTag.class, false);
+    }
+}

--- a/src/main/java/com/denizenscript/clientizen/objects/properties/item/ItemProperty.java
+++ b/src/main/java/com/denizenscript/clientizen/objects/properties/item/ItemProperty.java
@@ -1,0 +1,18 @@
+package com.denizenscript.clientizen.objects.properties.item;
+
+import com.denizenscript.clientizen.objects.ItemTag;
+import com.denizenscript.denizencore.objects.ObjectTag;
+import com.denizenscript.denizencore.objects.properties.ObjectProperty;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+
+public abstract class ItemProperty<TData extends ObjectTag> extends ObjectProperty<ItemTag, TData> {
+
+    public ItemStack getStack() {
+        return object.getStack();
+    }
+
+    public boolean is(Item item) {
+        return getStack().isOf(item);
+    }
+}

--- a/src/main/java/com/denizenscript/clientizen/objects/properties/item/ItemServerScript.java
+++ b/src/main/java/com/denizenscript/clientizen/objects/properties/item/ItemServerScript.java
@@ -1,0 +1,46 @@
+package com.denizenscript.clientizen.objects.properties.item;
+
+import com.denizenscript.clientizen.objects.ItemTag;
+import com.denizenscript.denizencore.objects.Mechanism;
+import com.denizenscript.denizencore.objects.core.ElementTag;
+import com.denizenscript.denizencore.objects.properties.PropertyParser;
+
+public class ItemServerScript extends ItemProperty<ElementTag> {
+
+    // <--[tag]
+    // @attribute <ItemTag.server_script>
+    // @returns ElementTag
+    // @group scripts
+    // @description
+    // Returns the name of an item's server-side item script, if it has one.
+    // -->
+
+    public static boolean describes(ItemTag item) {
+        return true;
+    }
+
+    @Override
+    public ElementTag getPropertyValue() {
+        return object.script != null ? new ElementTag(object.script) : null;
+    }
+
+    @Override
+    public String getPropertyId() {
+        return "script";
+    }
+
+    @Override
+    public void setPropertyValue(ElementTag value, Mechanism mechanism) {
+        if (object.script != null) {
+            mechanism.echoError("Cannot set a script on an item that already has one.");
+            return;
+        }
+        object.script = value.asString();
+    }
+
+    public static void register() {
+        PropertyParser.registerTag(ItemServerScript.class, ElementTag.class, "server_script", (attribute, prop) -> prop.getPropertyValue());
+        // Intentionally undocumented, internal purpose only
+        PropertyParser.registerMechanism(ItemServerScript.class, ElementTag.class, "script", (prop, mechanism, input) -> prop.setPropertyValue(input, mechanism));
+    }
+}


### PR DESCRIPTION
## Additions

- `ItemTag` object type.
- `ItemProperty` abstract property class for item proeprties.
- `ItemDurability` example property.
- `ItemServerScript` internal/hidden property to properly persist item scripts when passing `ItemTag`s `S->C->S`.
- `ItemTag.server_script` tag, returns the value from the above property.

## Notes

- The server supports getting items from item/book scripts, which isn't supported in here for obvious reasons.

Closes #10 